### PR TITLE
Add v1alpha2 version CRD for podGroup and queue

### DIFF
--- a/chart/volcano/templates/scheduling_v1alpha2_podgroup.yaml
+++ b/chart/volcano/templates/scheduling_v1alpha2_podgroup.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podgroups.scheduling.sigs.dev
+spec:
+  group: scheduling.sigs.dev
+  names:
+    kind: PodGroup
+    plural: podgroups
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            minMember:
+              format: int32
+              type: integer
+            queue:
+              type: string
+            priorityClassName:
+              type: string
+          type: object
+        status:
+          properties:
+            succeeded:
+              format: int32
+              type: integer
+            failed:
+              format: int32
+              type: integer
+            running:
+              format: int32
+              type: integer
+          type: object
+      type: object
+  version: v1alpha2

--- a/chart/volcano/templates/scheduling_v1alpha2_queue.yaml
+++ b/chart/volcano/templates/scheduling_v1alpha2_queue.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: queues.scheduling.sigs.dev
+spec:
+  group: scheduling.sigs.dev
+  names:
+    kind: Queue
+    plural: queues
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            weight:
+              format: int32
+              type: integer
+          type: object
+        status:
+          properties:
+            unknown:
+              format: int32
+              type: integer
+            pending:
+              format: int32
+              type: integer
+            running:
+              format: int32
+              type: integer
+          type: object
+      type: object
+  version: v1alpha2


### PR DESCRIPTION
We need to have CRD for version v1alpha2, so that it can be used in Volcano CI for supporting both versions(podGroup and queue) in Code